### PR TITLE
fix MsgSvrID integer overflow

### DIFF
--- a/packages/core/src/lib/client.ts
+++ b/packages/core/src/lib/client.ts
@@ -229,7 +229,7 @@ export class Wcferry {
     dbSqlQuery(
         db: string,
         sql: string
-    ): Record<string, string | number | Buffer | undefined>[] {
+    ): Record<string, string | number | BigInt | Buffer | undefined>[] {
         const req = new wcf.Request({
             func: wcf.Functions.FUNC_EXEC_DB_QUERY,
             query: new wcf.DbQuery({ db, sql }),
@@ -956,6 +956,10 @@ function parseDbField(type: number, content: Uint8Array) {
     // self._SQL_TYPES = {1: int, 2: float, 3: lambda x: x.decode("utf-8"), 4: bytes, 5: lambda x: None}
     switch (type) {
         case 1:
+            const bigIntContent = BigInt(uint8Array2str(content));
+            if (bigIntContent > Number.MAX_SAFE_INTEGER) {
+                return bigIntContent;
+            }
             return Number.parseInt(uint8Array2str(content), 10);
         case 2:
             return Number.parseFloat(uint8Array2str(content));

--- a/packages/core/src/lib/client.ts
+++ b/packages/core/src/lib/client.ts
@@ -229,7 +229,7 @@ export class Wcferry {
     dbSqlQuery(
         db: string,
         sql: string
-    ): Record<string, string | number | BigInt | Buffer | undefined>[] {
+    ): Record<string, string | number | Buffer | undefined>[] {
         const req = new wcf.Request({
             func: wcf.Functions.FUNC_EXEC_DB_QUERY,
             query: new wcf.DbQuery({ db, sql }),
@@ -956,11 +956,14 @@ function parseDbField(type: number, content: Uint8Array) {
     // self._SQL_TYPES = {1: int, 2: float, 3: lambda x: x.decode("utf-8"), 4: bytes, 5: lambda x: None}
     switch (type) {
         case 1:
-            const bigIntContent = BigInt(uint8Array2str(content));
+            const strContent = uint8Array2str(content);
+            const bigIntContent = BigInt(strContent);
             if (bigIntContent > Number.MAX_SAFE_INTEGER) {
-                return bigIntContent;
+                // bigInt 在JSON.stringify时会出问题，还是返回字符串吧
+                // TypeError: Do not know how to serialize a BigInt
+                return strContent;
             }
-            return Number.parseInt(uint8Array2str(content), 10);
+            return Number.parseInt(strContent, 10);
         case 2:
             return Number.parseFloat(uint8Array2str(content));
         case 3:


### PR DESCRIPTION
本地调试的时候发现 ```dbSqlQuery``` 查出来的 ```MsgSvrID``` 返回去查消息会找不到

排查后发现64位下JS最大支持整数为```2^53-1``` ```(9007199254740991)```

而通过监听 message 发现 ```MsgSvrID``` 超出JS整数范围，如 ```95402283214985697```

其他client没问题是因为JS的number类型包括小数，会影响整数范围

所以在 ```parseDbField``` 中加入了 ```BigInt``` 判断